### PR TITLE
Solucionado de errores de tipo(Response y Request) y modulo de import Fibonacci

### DIFF
--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,8 +1,9 @@
 // Endpoint for querying the fibonacci numbers
 
-const fibonacci = require("./fib");
+import fibonacci from "./fib";
+import {Request, Response} from "express";
 
-export default (req, res) => {
+export default (req: Request, res: Response) => {
   const { num } = req.params;
 
   const fibN = fibonacci(parseInt(num));


### PR DESCRIPTION
## Modificación en el archivo
- Reescritura de la forma de importación de modulo `Fibonacci` dado que se encontraba en una versión antigua.
- Importación de los tipos `Request` y `Response` para inclusión de tipo en el parámetro `req` y `res` de la exportación por defecto.

## Métodos de prueba
- En linux, mediante la herramienta de análisis `ESLint`.
> [!NOTE]
> Comando: `npm run lint`.
- Ejecutando los casos de prueba que se encontraban en el repositorio.
> [!NOTE]
> Comando: `npm run test`.